### PR TITLE
Handle ghost users - users who are no longer in the org

### DIFF
--- a/get-deployment-metrics.py
+++ b/get-deployment-metrics.py
@@ -7,6 +7,7 @@ import argparse
 import fnmatch
 from agithub.GitHub import GitHub
 from dotenv import load_dotenv
+from pprint import pprint
 
 
 def get_mins_secs_str(duration_in_ms):
@@ -209,9 +210,14 @@ if __name__ == "__main__":
                         summary_stats[repo_name] = dict()
 
                     for workflow_run in workflow_runs:
+                        #logging.debug("NEW WORKFLOW RUN FOUND...")
+                        #pprint(workflow_run)
                         workflow_status = workflow_run["conclusion"]
                         job_id = workflow_run["id"]
-                        actor = workflow_run["triggering_actor"]["login"]
+                        if workflow_run["triggering_actor"]:
+                            actor = workflow_run["triggering_actor"]["login"]
+                        else:
+                            actor = "User is no longer in the org"
 
                         logging.debug("Workflow run was triggered by {}".format(actor))
 

--- a/get-deployment-metrics.py
+++ b/get-deployment-metrics.py
@@ -8,6 +8,7 @@ import fnmatch
 from agithub.GitHub import GitHub
 from dotenv import load_dotenv
 
+
 def get_mins_secs_str(duration_in_ms):
     duration_secs, duration_in_ms = divmod(duration_in_ms, 1000)
     duration_mins, duration_secs = divmod(duration_secs, 60)

--- a/get-deployment-metrics.py
+++ b/get-deployment-metrics.py
@@ -7,8 +7,6 @@ import argparse
 import fnmatch
 from agithub.GitHub import GitHub
 from dotenv import load_dotenv
-from pprint import pprint
-
 
 def get_mins_secs_str(duration_in_ms):
     duration_secs, duration_in_ms = divmod(duration_in_ms, 1000)
@@ -210,8 +208,6 @@ if __name__ == "__main__":
                         summary_stats[repo_name] = dict()
 
                     for workflow_run in workflow_runs:
-                        #logging.debug("NEW WORKFLOW RUN FOUND...")
-                        #pprint(workflow_run)
                         workflow_status = workflow_run["conclusion"]
                         job_id = workflow_run["id"]
                         if workflow_run["triggering_actor"]:


### PR DESCRIPTION
TIL that when a user leaves the org, deploys are assigned to the "Ghost" user!  The `triggering_actor` becomes empty

```'triggering_actor': None,```

and everything becomes assigned to this special GH user called "ghost"

```
{'actor': {'avatar_url': 'https://avatars.githubusercontent.com/u/10137?v=4',
           'events_url': 'https://api.github.com/users/ghost/events{/privacy}',
           'followers_url': 'https://api.github.com/users/ghost/followers',
           'following_url': 'https://api.github.com/users/ghost/following{/other_user}',
           'gists_url': 'https://api.github.com/users/ghost/gists{/gist_id}',
           'gravatar_id': '',
           'html_url': 'https://github.com/ghost',
           'id': 10137,
           'login': 'ghost',
           'node_id': 'MDQ6VXNlcjEwMTM3',
           'organizations_url': 'https://api.github.com/users/ghost/orgs',
           'received_events_url': 'https://api.github.com/users/ghost/received_events',
           'repos_url': 'https://api.github.com/users/ghost/repos',
           'site_admin': False,
           'starred_url': 'https://api.github.com/users/ghost/starred{/owner}{/repo}',
           'subscriptions_url': 'https://api.github.com/users/ghost/subscriptions',
           'type': 'User',
           'url': 'https://api.github.com/users/ghost',
           'user_view_type': 'public'},
```