### PR TITLE
chore(): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "appsec"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "patch"
+        - "minor"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -21,5 +21,5 @@ jobs:
         run: pip install -r requirements-format.txt
 
       - name: Format
-        run:  |
+        run: |
           black . --check


### PR DESCRIPTION
# Pin GitHub Actions to commit SHAs

## Description of change

Pins all third-party GitHub Actions to specific commit SHAs to protect
against tag hijacking / supply chain attacks. Actions from the `rewindio`
org are excluded and remain at their original version refs.

Uses [ratchet](https://github.com/sethvargo/ratchet) for SHA resolution.

## Testing Performed
